### PR TITLE
TableViewCellにお気に入りボタンの追加

### DIFF
--- a/CTAProject/Extension/SearchShopsTableViewCell+RxDataSources.swift
+++ b/CTAProject/Extension/SearchShopsTableViewCell+RxDataSources.swift
@@ -1,0 +1,34 @@
+//
+//  SearchShopsTableViewCell.swift
+//  CTAProject
+//
+//  Created by Tomoya Tanaka on 2022/03/08.
+//
+
+import RxDataSources
+
+typealias SearchShopsTableViewSection = SearchShopsTableViewCell.SearchShopsTableViewSection
+typealias SearchShopsTableViewCellData = SearchShopsTableViewCell.SearchShopsTableViewCellData
+
+extension SearchShopsTableViewCell {
+    struct SearchShopsTableViewCellData {
+        let shopName: String
+        let locationName: String
+        let price: String
+        let shopImageURL: String
+        let favorited: Bool
+    }
+
+    struct SearchShopsTableViewSection {
+        var items: [SearchShopsTableViewCellData]
+    }
+
+}
+
+extension SearchShopsTableViewSection: SectionModelType {
+    typealias Item = SearchShopsTableViewCellData
+    init (original: Self, items: [Item]) {
+        self = original
+        self.items = items
+    }
+}

--- a/CTAProject/Model/Components/SearchShopsTableViewCellData.swift
+++ b/CTAProject/Model/Components/SearchShopsTableViewCellData.swift
@@ -1,8 +1,8 @@
 //
-//  SearchShopsTableViewCell.swift
+//  SearchShopsTableViewCellData.swift
 //  CTAProject
 //
-//  Created by Tomoya Tanaka on 2022/03/08.
+//  Created by Tomoya Tanaka on 2022/03/14.
 //
 
 import RxDataSources

--- a/CTAProject/UIComponent/ViewController/SearchShopsViewController.swift
+++ b/CTAProject/UIComponent/ViewController/SearchShopsViewController.swift
@@ -46,15 +46,25 @@ final class SearchShopsViewController: UIViewController {
         setupView()
 
         let dataSource = RxTableViewSectionedReloadDataSource<SearchShopsTableViewSection>(
-            configureCell: { dataSource, tableView, indexPath, item in
+            configureCell: { [disposeBag] dataSource, tableView, indexPath, item in
                 let cell = tableView.dequeueReusableCell(withIdentifier: SearchShopsTableViewCell.reuseIdentifier, for: indexPath)
 
                 guard let cell = cell as? SearchShopsTableViewCell else {
                     fatalError("SearchShopsTableViewCell is not configured properly")
                 }
 
-                cell.configureCell(item)
+                Observable.just(item)
+                    .bind(to: cell.rx.bindCellData)
+                    .disposed(by: disposeBag)
+
+                // TODO: 次のPRでcellのボタンとViewModelをバインドする
+                cell.didTapFavoriteButton.emit(onNext: { _ in
+                    print("emit")
+                })
+                .disposed(by: cell.disposeBag)
+
                 return cell
+
             }
         )
 
@@ -93,7 +103,8 @@ final class SearchShopsViewController: UIViewController {
                         locationName: shop.stationName,
                         price: shop.budget.name,
                         shopImageURL: shop.logoImage,
-                        favorited: false)
+                        favorited: true
+                    )
                 }
                 let sections = [SearchShopsTableViewSection(items: items)]
                 return sections

--- a/CTAProject/UIComponent/ViewController/SearchShopsViewController.swift
+++ b/CTAProject/UIComponent/ViewController/SearchShopsViewController.swift
@@ -8,6 +8,7 @@
 import Moya
 import PKHUD
 import RxCocoa
+import RxDataSources
 import RxSwift
 import SnapKit
 import UIKit
@@ -44,6 +45,19 @@ final class SearchShopsViewController: UIViewController {
         super.viewDidLoad()
         setupView()
 
+        let dataSource = RxTableViewSectionedReloadDataSource<SearchShopsTableViewSection>(
+            configureCell: { dataSource, tableView, indexPath, item in
+                let cell = tableView.dequeueReusableCell(withIdentifier: SearchShopsTableViewCell.reuseIdentifier, for: indexPath)
+
+                guard let cell = cell as? SearchShopsTableViewCell else {
+                    fatalError("SearchShopsTableViewCell is not configured properly")
+                }
+
+                cell.configureCell(item)
+                return cell
+            }
+        )
+
         searchBar.rx.searchButtonClicked
             .subscribe(onNext: { [searchBar] _ in
                 searchBar.resignFirstResponder()
@@ -71,17 +85,20 @@ final class SearchShopsViewController: UIViewController {
 
         viewModel.outputs.shops
             .asObservable()
-            .bind(to: tableView.rx.items(
-                cellIdentifier: SearchShopsTableViewCell.reuseIdentifier,
-                cellType: SearchShopsTableViewCell.self)
-            ) { index, shop, cell in
-                cell.configureCell(
-                    shopName: shop.name,
-                    locationName: shop.stationName,
-                    price: shop.budget.name,
-                    shopImageURL: shop.logoImage
-                )
+            .map { (shops: [HotPepperAPI.Shop]) -> [SearchShopsTableViewSection] in
+                let items = shops.map { shop -> SearchShopsTableViewCellData in
+                    // NOTE: 本来ViewModelに書く内容ですが、変更範囲が大きくなってしまうので一旦ここに書いています。
+                    return SearchShopsTableViewCellData(
+                        shopName: shop.name,
+                        locationName: shop.stationName,
+                        price: shop.budget.name,
+                        shopImageURL: shop.logoImage,
+                        favorited: false)
+                }
+                let sections = [SearchShopsTableViewSection(items: items)]
+                return sections
             }
+            .bind(to: tableView.rx.items(dataSource: dataSource))
             .disposed(by: disposeBag)
 
         viewModel.outputs.loading

--- a/CTAProject/UIResource/Resource/Localizable/Localizable.strings
+++ b/CTAProject/UIResource/Resource/Localizable/Localizable.strings
@@ -4,3 +4,5 @@
 "SearchShopsAlertModalLabelText" = "文字数が50文字を超過しています。";
 "SearchShopsCloseButtonTitle" = "閉じる";
 "SearchShopsTabTitle" = "リスト";
+"SystemStar" = "star";
+"SystemStarFill" = "star.fill";

--- a/Podfile
+++ b/Podfile
@@ -12,6 +12,7 @@ target 'CTAProject' do
 	pod 'SnapKit', '~> 5.0.0'
 	pod 'RxSwift'
 	pod 'RxCocoa'
+	pod 'RxDataSources'
 	pod 'Moya'
 	pod 'Moya/RxSwift'
 	pod 'PKHUD'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,5 +1,6 @@
 PODS:
   - Alamofire (5.5.0)
+  - Differentiator (5.0.0)
   - Moya (15.0.0):
     - Moya/Core (= 15.0.0)
   - Moya/Core (15.0.0):
@@ -14,6 +15,10 @@ PODS:
   - RxCocoa (6.2.0):
     - RxRelay (= 6.2.0)
     - RxSwift (= 6.2.0)
+  - RxDataSources (5.0.0):
+    - Differentiator (~> 5.0)
+    - RxCocoa (~> 6.0)
+    - RxSwift (~> 6.0)
   - RxRelay (6.2.0):
     - RxSwift (= 6.2.0)
   - RxSwift (6.2.0)
@@ -33,6 +38,7 @@ DEPENDENCIES:
   - PKHUD
   - RxBlocking
   - RxCocoa
+  - RxDataSources
   - RxSwift
   - RxTest
   - SnapKit (~> 5.0.0)
@@ -43,11 +49,13 @@ DEPENDENCIES:
 SPEC REPOS:
   trunk:
     - Alamofire
+    - Differentiator
     - Moya
     - Nuke
     - PKHUD
     - RxBlocking
     - RxCocoa
+    - RxDataSources
     - RxRelay
     - RxSwift
     - RxTest
@@ -58,11 +66,13 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   Alamofire: 1c4fb5369c3fe93d2857c780d8bbe09f06f97e7c
+  Differentiator: e8497ceab83c1b10ca233716d547b9af21b9344d
   Moya: 138f0573e53411fb3dc17016add0b748dfbd78ee
   Nuke: 279f17a599fd1c83cf51de5e0e1f2db143a287b0
   PKHUD: 98f3e4bc904b9c916f1c5bb6d765365b5357291b
   RxBlocking: 0b29f7d2079109a8de49c411381bed7c33ef1eeb
   RxCocoa: 4baf94bb35f2c0ab31bc0cb9f1900155f646ba42
+  RxDataSources: aa47cc1ed6c500fa0dfecac5c979b723542d79cf
   RxRelay: e72dbfd157807478401ef1982e1c61c945c94b2f
   RxSwift: d356ab7bee873611322f134c5f9ef379fa183d8f
   RxTest: 0c692fa672b694373ba86d2b00033595297a2831
@@ -71,6 +81,6 @@ SPEC CHECKSUMS:
   SwiftLint: 06ac37e4d38c7068e0935bb30cda95f093bec761
   Unio: 6e57bd33dbcf38d281b0b420f75c0eae3bef0cf3
 
-PODFILE CHECKSUM: cdc4b8c52bb008fd0d6aac243a0b3bfbcf2c4442
+PODFILE CHECKSUM: c4900022ccc5645af90a58bee72b947393e45938
 
 COCOAPODS: 1.11.2


### PR DESCRIPTION
## 関連URL
[ 【タスク2】お気に入り機能の実装 ](https://github.com/sosuiiii/CTAProject2022/issues/3)

## 前提

## 仕様
RxDataSourcesを使って、RxSwiftっぽく書くことを意識しました！

## 対応内容
店舗検索画面のCellにお気に入りボタンを追加しました！

### 実装機能1
[ bc47073c41cbb2584f277e818e46337be3076d6e ]
- RxDataSourcesの追加

### 実装機能2
[ b511c568cc9816e7ef8147b9133cb539e145569a ]
- SearchShopsTableViewCellにRxDataSources用のExtensionを追加

### 実装機能3
[ b599b7e9de89820e947e0e3fa167751165bb7e55 ]
- SearchShopsTableViewCellにお気に入りボタンを追加

### 実装機能4
[ 1ba5209a88d320cc7b3667ff94586da95c231984 ]
- SearchShopsTableViewCellの初期化方法をRxDataSourcesを使って変更

## レビュー観点
TableViewCellのStateの管理だったり、イベントの流し方に関してもっといい方法があれば教えて頂きたいです！

## スクリーンショット
| before | after |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/22112440/157238623-524ecd96-10e8-4f32-b10a-30fa9b95eb96.png" width="400px"> | <img src="https://user-images.githubusercontent.com/22112440/157238500-220993b7-61dc-4efb-86c4-337af0852cba.png" width="400px"> |