### PR TITLE
店舗お気に入り機能の実装

### DIFF
--- a/CTAProject/Model/Components/SearchShopsTableViewCellData.swift
+++ b/CTAProject/Model/Components/SearchShopsTableViewCellData.swift
@@ -12,11 +12,12 @@ typealias SearchShopsTableViewCellData = SearchShopsTableViewCell.SearchShopsTab
 
 extension SearchShopsTableViewCell {
     struct SearchShopsTableViewCellData {
+        let id: String
         let shopName: String
         let locationName: String
         let price: String
         let shopImageURL: String
-        let favorited: Bool
+        var favorited: Bool
     }
 
     struct SearchShopsTableViewSection {
@@ -30,5 +31,18 @@ extension SearchShopsTableViewSection: SectionModelType {
     init (original: Self, items: [Item]) {
         self = original
         self.items = items
+    }
+}
+
+extension SearchShopsTableViewCellData {
+    static var exampleInstance: SearchShopsTableViewCellData {
+        return SearchShopsTableViewCellData(
+            id: "id",
+            shopName: "shopName",
+            locationName: "locationName",
+            price: "price",
+            shopImageURL: "shopImageURL",
+            favorited: false
+        )
     }
 }

--- a/CTAProject/Model/Entity/FavoriteShop.swift
+++ b/CTAProject/Model/Entity/FavoriteShop.swift
@@ -1,0 +1,46 @@
+//
+//  FavoriteShop.swift
+//  CTAProject
+//
+//  Created by Tomoya Tanaka on 2022/03/21.
+//
+
+import Foundation
+import RealmSwift
+
+class FavoriteShop: Object {
+    @Persisted var id: String = ""
+    @Persisted var stationName: String = ""
+    @Persisted var name: String = ""
+    @Persisted var budget: Budget?
+    @Persisted var logoImage: String = ""
+
+    override static func primaryKey() -> String? {
+        return "id"
+    }
+
+    convenience init(_ shop: SearchShopsTableViewCellData) {
+        self.init()
+        id = shop.id
+        stationName = shop.locationName
+        name = shop.shopName
+        budget = .init(shop.price)
+        logoImage = shop.shopImageURL
+    }
+}
+
+class Budget: EmbeddedObject {
+    @Persisted var name: String
+    
+    convenience init(_ price: String) {
+        self.init()
+        name = price
+    }
+}
+
+
+extension FavoriteShop {
+    static var exampleInstance: FavoriteShop {
+        return FavoriteShop(SearchShopsTableViewCellData.exampleInstance)
+    }
+}

--- a/CTAProject/Model/HotPepperAPI/Entity/Shop.swift
+++ b/CTAProject/Model/HotPepperAPI/Entity/Shop.swift
@@ -13,6 +13,7 @@ extension HotPepperAPI {
     }
     
     struct Shop: Decodable {
+        let id: String
         let stationName: String
         let name: String
         let budget: Budget

--- a/CTAProject/Model/RealmError.swift
+++ b/CTAProject/Model/RealmError.swift
@@ -1,0 +1,24 @@
+//
+//  RealmError.swift
+//  CTAProject
+//
+//  Created by Tomoya Tanaka on 2022/03/24.
+//
+
+import Foundation
+
+enum RealmError: Error {
+    case objectIsNotFound
+    case idIsAlreadyTaken
+}
+
+extension RealmError: LocalizedError {
+    var errorDescription: String? {
+        switch self {
+        case .objectIsNotFound:
+            return "object is not found"
+        case .idIsAlreadyTaken:
+            return "id is already taken"
+        }
+    }
+}

--- a/CTAProject/Model/Repositories/FavoritedShopsRepository.swift
+++ b/CTAProject/Model/Repositories/FavoritedShopsRepository.swift
@@ -1,0 +1,63 @@
+//
+//  FavoritedShopsRepository.swift
+//  CTAProject
+//
+//  Created by Tomoya Tanaka on 2022/03/21.
+//
+
+import Foundation
+import RealmSwift
+import RxSwift
+
+/// @mockable
+protocol FavoritedShopsRepositoryType {
+    func checkIfShopFavorited(_ id: String) -> Bool
+    func addFavoriteShop(_ favoriteShop: FavoriteShop) -> Single<FavoriteShop>
+    func removeFavoriteShop(_ id: String) -> Single<Void>
+}
+
+final class FavoritedShopsRepository: FavoritedShopsRepositoryType {
+
+    private let realm: Realm
+
+    init(realm: Realm) {
+        self.realm = realm
+    }
+
+    func checkIfShopFavorited(_ id: String) -> Bool {
+        var isFavorited = false
+        let object = realm.object(ofType: FavoriteShop.self, forPrimaryKey: id)
+        if object != nil { isFavorited = true }
+        return isFavorited
+    }
+
+    func addFavoriteShop(_ favoriteShop: FavoriteShop) -> Single<FavoriteShop> {
+        let object = realm.object(ofType: FavoriteShop.self, forPrimaryKey: favoriteShop.id)
+        guard object == nil else {
+            return Single<FavoriteShop>.error(RealmError.idIsAlreadyTaken)
+        }
+        do {
+            try realm.write {
+                realm.add(favoriteShop)
+            }
+            return Single<FavoriteShop>.just(favoriteShop)
+        } catch let error as NSError {
+            return Single<FavoriteShop>.error(error)
+        }
+    }
+
+    func removeFavoriteShop(_ id: String) -> Single<Void> {
+        let object = realm.object(ofType: FavoriteShop.self, forPrimaryKey: id)
+        guard let object = object else {
+            return Single<Void>.error(RealmError.objectIsNotFound)
+        }
+        do {
+            try realm.write {
+                realm.delete(object)
+            }
+        } catch let error {
+            return Single<Void>.error(error)
+        }
+        return Single<Void>.just(())
+    }
+}

--- a/CTAProject/UIComponent/ViewController/TabBarController.swift
+++ b/CTAProject/UIComponent/ViewController/TabBarController.swift
@@ -6,6 +6,7 @@
 //
 
 import Moya
+import RealmSwift
 import UIKit
 
 final class TabBarController: UITabBarController {
@@ -24,9 +25,13 @@ final class TabBarController: UITabBarController {
         var viewControllers: [UIViewController] = []
         let viewModel: SearchShopsViewModel = {
             let provider = MoyaProvider<MultiTarget>()
-            let repository = SearchShopsRepository(provider: provider)
+            let searchShopsRepository = SearchShopsRepository(provider: provider)
+            let favoritedShopsRepository = FavoritedShopsRepository(realm: try! Realm())
             let viewModel = SearchShopsViewModel(
-                model: SearchShopsModel(searchShopsRepository: repository)
+                model: SearchShopsModel(
+                    searchShopsRepository: searchShopsRepository,
+                    favoritedShopsRepository: favoritedShopsRepository
+                )
             )
             return viewModel
         }()

--- a/CTAProject/UILogic/SearchShops/SearchShopsViewModel.swift
+++ b/CTAProject/UILogic/SearchShops/SearchShopsViewModel.swift
@@ -13,13 +13,15 @@ import RxSwift
 // NOTE: 外部から受ける命令
 protocol SearchShopsViewModelInputs {
     var searchWord: AnyObserver<String> { get }
+    var tapFavoriteButton: AnyObserver<IndexPath> { get }
 }
 
 // NOTE: 外部に渡す値
 protocol SearchShopsViewModelOutputs: SearchShops {
-    var shops: Driver<Shops> { get }
+    var shops: Driver<[SearchShopsTableViewCellData]> { get }
     var loading: Driver<Bool> { get }
     var hasSearchWordCountExceededError: Driver<Bool> { get }
+    var didPressFavoriteButton: Driver<IndexPath> { get }
 }
 
 protocol SearchShopsViewModelType {
@@ -30,26 +32,40 @@ protocol SearchShopsViewModelType {
 final class SearchShopsViewModel: SearchShopsViewModelInputs, SearchShopsViewModelOutputs {
 
     var searchWord: AnyObserver<String>
-    var shops: Driver<Shops>
+    var tapFavoriteButton: AnyObserver<IndexPath>
+    var shops: Driver<[SearchShopsTableViewCellData]>
     var loading: Driver<Bool>
     var hasSearchWordCountExceededError: Driver<Bool>
+    var didPressFavoriteButton: Driver<IndexPath>
 
     private var disposeBag = DisposeBag()
 
     init(model: SearchShopsModelType) {
         let _searchWord = PublishRelay<String>()
-        let _shops = BehaviorRelay<Shops>(value: [])
+        let _tapFavoriteButton = PublishRelay<IndexPath>()
+
+        let _shops = BehaviorRelay<[SearchShopsTableViewCellData]>(value: [])
         let _loading = PublishRelay<Bool>()
         let _hasSearchWordCountExceededError = PublishRelay<Bool>()
+        let _didPressFavoriteButton = PublishRelay<IndexPath>()
 
+        // MARK: Input
         searchWord = AnyObserver<String> { event in
             guard let keyword = event.element else { return }
             _searchWord.accept(keyword)
         }
+        tapFavoriteButton = AnyObserver<IndexPath> { event in
+            guard let tapFavoriteButton = event.element else { return }
+            _tapFavoriteButton.accept(tapFavoriteButton)
+        }
+
+        // MARK: Output
         shops = _shops.asDriver()
         loading = _loading.asDriver(onErrorJustReturn: false)
         hasSearchWordCountExceededError = _hasSearchWordCountExceededError.asDriver(onErrorDriveWith: .empty())
+        didPressFavoriteButton = _didPressFavoriteButton.asDriver(onErrorDriveWith: .empty())
 
+        // MARK: SearchQuery
         let searchWordValidationResult = _searchWord.flatMap { searchWord -> Observable<SearchWordValidator.ValidationResult> in
             return .just(SearchWordValidator.validate(searchWord))
         }
@@ -62,7 +78,7 @@ final class SearchShopsViewModel: SearchShopsViewModelInputs, SearchShopsViewMod
 
         let searchResult = searchWordValidationResult
             .filterValid()
-            .flatMap { searchWord -> Single<Shops> in
+            .flatMap { searchWord -> Single<[SearchShopsTableViewCellData]> in
                 _loading.accept(true)
                 return model.fetchShops(keyword: searchWord)
             }
@@ -75,6 +91,40 @@ final class SearchShopsViewModel: SearchShopsViewModelInputs, SearchShopsViewMod
 
         searchResult
             .bind(to: _shops)
+            .disposed(by: disposeBag)
+
+        // MARK: OnSelectedCell
+        let selectedCell = _tapFavoriteButton.flatMap { indexPath -> Observable<(SearchShopsTableViewCellData, IndexPath)> in
+            let shop = _shops.value[indexPath.row]
+            return Observable.combineLatest(Observable.just(shop), Observable.just(indexPath))
+        }
+        .share()
+
+        selectedCell
+            .filter { (shop, _) in !shop.favorited }
+            .flatMap { (shop, indexPath) -> Single<IndexPath> in
+                return model.addFavoriteShop(FavoriteShop(shop))
+                    .map { _ in return indexPath }
+            }
+            .bind(to: _didPressFavoriteButton)
+            .disposed(by: disposeBag)
+
+        selectedCell
+            .filter { (shop, _) in shop.favorited }
+            .flatMap { (shop, indexPath) -> Single<IndexPath> in
+                return model.removeFavoriteShop(shop.id)
+                    .map { _ in return indexPath }
+            }
+            .bind(to: _didPressFavoriteButton)
+            .disposed(by: disposeBag)
+
+        _didPressFavoriteButton
+            .map { indexPath in
+                var shops = _shops.value
+                shops[indexPath.row].favorited = !shops[indexPath.row].favorited
+                _shops.accept(shops)
+            }
+            .subscribe()
             .disposed(by: disposeBag)
 
     }

--- a/CTAProjectTests/FavoritedShopsRepositoryTests.swift
+++ b/CTAProjectTests/FavoritedShopsRepositoryTests.swift
@@ -1,0 +1,82 @@
+//
+//  FavoritedShopsRepositoryTests.swift
+//  CTAProjectTests
+//
+//  Created by Tomoya Tanaka on 2022/03/25.
+//
+
+@testable import CTAProject
+@testable import RealmSwift
+@testable import RxRelay
+@testable import RxSwift
+@testable import RxTest
+import XCTest
+
+class FavoritedShopsRepositoryTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        Realm.Configuration.defaultConfiguration.inMemoryIdentifier = self.name
+    }
+
+    func test_checkIfShopFavoritedSuccess() throws {
+        let dependency = Dependency(withInitialData: true)
+        let result = dependency.testTarget.checkIfShopFavorited(dependency.favoriteShop.id)
+        XCTAssertEqual(result, true)
+    }
+
+    func test_checkIfShopFavoritedFailure() throws {
+        let dependency = Dependency(withInitialData: false)
+        let result = dependency.testTarget.checkIfShopFavorited("notFoundID")
+        XCTAssertEqual(result, false)
+    }
+
+    func test_addFavoriteShopSuccess() throws {
+        let dependency = Dependency(withInitialData: false)
+        let addFavoriteShop = WatchStream(dependency.testTarget.addFavoriteShop(dependency.favoriteShop).asObservable())
+        XCTAssertEqual(addFavoriteShop.result.first??.id, dependency.favoriteShop.id)
+    }
+
+    func test_addFavoriteShopFailure() throws {
+        let dependency = Dependency(withInitialData: true)
+        let addFavoriteShop = WatchStream(dependency.testTarget.addFavoriteShop(dependency.favoriteShop).asObservable())
+        XCTAssertEqual(addFavoriteShop.errors.first??.localizedDescription, RealmError.idIsAlreadyTaken.localizedDescription)
+    }
+
+    func test_removeFavoriteShopSuccess() throws {
+        let dependency = Dependency(withInitialData: true)
+        let removeFavoriteShop = WatchStream(dependency.testTarget.removeFavoriteShop(dependency.favoriteShop.id).asObservable())
+        XCTAssertEqual(removeFavoriteShop.result.count, 2)
+    }
+
+    func test_removeFavoriteShopFailure() throws {
+        let dependency = Dependency(withInitialData: false)
+        let removeFavoriteShop = WatchStream(dependency.testTarget.removeFavoriteShop(dependency.favoriteShop.id).asObservable())
+        XCTAssertEqual(removeFavoriteShop.errors.first??.localizedDescription, RealmError.objectIsNotFound.localizedDescription)
+    }
+}
+
+extension FavoritedShopsRepositoryTests {
+    struct Dependency {
+        let realm: Realm
+        let testScheduler: TestScheduler
+        let testTarget: FavoritedShopsRepository
+        let favoriteShop: FavoriteShop
+
+        init(withInitialData: Bool) {
+            realm = try! Realm()
+            testScheduler = TestScheduler(initialClock: 0)
+            testTarget = FavoritedShopsRepository(realm: realm)
+            favoriteShop = FavoriteShop.exampleInstance
+            if withInitialData {
+                addExampleData()
+            }
+        }
+
+        private func addExampleData() {
+            try! realm.write {
+                realm.create(FavoriteShop.self, value: FavoriteShop.exampleInstance, update: .modified)
+            }
+        }
+    }
+}

--- a/CTAProjectTests/WatchStream.swift
+++ b/CTAProjectTests/WatchStream.swift
@@ -26,4 +26,12 @@ struct WatchStream<Element> {
     var value: Element? {
         return observer.events.last.flatMap { $0.value }?.element
     }
+
+    var result: [Element?] {
+        return observer.events.map { $0.value.element }
+    }
+
+    var errors: [Error?] {
+        return observer.events.map { $0.value.error }
+    }
 }

--- a/Podfile
+++ b/Podfile
@@ -10,6 +10,7 @@ target 'CTAProject' do
   pod 'SwiftGen'
   pod 'Unio'
 	pod 'SnapKit', '~> 5.0.0'
+	pod 'RealmSwift'
 	pod 'RxSwift'
 	pod 'RxCocoa'
 	pod 'RxDataSources'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -10,6 +10,11 @@ PODS:
     - RxSwift (~> 6.0)
   - Nuke (10.7.1)
   - PKHUD (5.3.0)
+  - Realm (10.24.2):
+    - Realm/Headers (= 10.24.2)
+  - Realm/Headers (10.24.2)
+  - RealmSwift (10.24.2):
+    - Realm (= 10.24.2)
   - RxBlocking (6.2.0):
     - RxSwift (= 6.2.0)
   - RxCocoa (6.2.0):
@@ -36,6 +41,7 @@ DEPENDENCIES:
   - Moya/RxSwift
   - Nuke
   - PKHUD
+  - RealmSwift
   - RxBlocking
   - RxCocoa
   - RxDataSources
@@ -53,6 +59,8 @@ SPEC REPOS:
     - Moya
     - Nuke
     - PKHUD
+    - Realm
+    - RealmSwift
     - RxBlocking
     - RxCocoa
     - RxDataSources
@@ -70,6 +78,8 @@ SPEC CHECKSUMS:
   Moya: 138f0573e53411fb3dc17016add0b748dfbd78ee
   Nuke: 279f17a599fd1c83cf51de5e0e1f2db143a287b0
   PKHUD: 98f3e4bc904b9c916f1c5bb6d765365b5357291b
+  Realm: c8421eee9ff92b16b4f91a313b5cc695c37c1921
+  RealmSwift: 10ed6fa09c36aaaff55e12afdc71802ec3ddb1c0
   RxBlocking: 0b29f7d2079109a8de49c411381bed7c33ef1eeb
   RxCocoa: 4baf94bb35f2c0ab31bc0cb9f1900155f646ba42
   RxDataSources: aa47cc1ed6c500fa0dfecac5c979b723542d79cf
@@ -81,6 +91,6 @@ SPEC CHECKSUMS:
   SwiftLint: 06ac37e4d38c7068e0935bb30cda95f093bec761
   Unio: 6e57bd33dbcf38d281b0b420f75c0eae3bef0cf3
 
-PODFILE CHECKSUM: c4900022ccc5645af90a58bee72b947393e45938
+PODFILE CHECKSUM: 629c3b275a47afef0ab4a3ae203f797480f60f2f
 
 COCOAPODS: 1.11.2


### PR DESCRIPTION
## 関連URL
[ 【タスク2】お気に入り機能の実装 ](https://github.com/sosuiiii/CTAProject2022/issues/3)

## 前提
Realmを導入してお気に入り機能を実装したい

## 仕様

## 対応内容

### 実装機能1
[ eff9bf9d753ddd84a845f521715943ddef7de6f3 ]
- RealmSwiftを追加

### 実装機能2
[ f25907b62cbb0afcf3c8941ff774966d5c29bfed ]
- RealmErrorの追加

### 実装機能3
[ 6f9748863ad58e6dce5f169117de4a3acba98989 ]
- SearchShopsTableViewCellDataにインスタンスを生成するメソッドを追加

### 実装機能4
[ 75cbf89146319420db2ce389726d513e6ddfc784 ]
- Shopにidを追加

### 実装機能5
[ 8742eb5c029302706d7f4b09f999817fde957ef1 ]
- FavoriteShopの追加

### 実装機能6
[ 555c8f12aa6a5014d159160685c6d4326f7279f1 ]
- FavoriteShopsRepositoryの追加

### 実装機能7
[ 3e4c2c04584d5f0b22964316393b2e6899fb3773 ]
- SearchShopsModelに機能を追加

### 実装機能8
[ 2b29beb34c199620523c441f68c89975f02d8259 ]
- SearchShopsViewModelに機能を追加

### 実装機能9
[ 9ff1145595a34384d341ca1e82f138c5d2bb0959 ]
- SearchShopsViewControllerにお気に入り機能を実装

### 実装機能10
[ 764163eb90fe602bc1041deda1c739cc66a83278 ]
- WatchStreamにUtility関数を追加

### 実装機能11
[  
12bbdc2758fe2c451a03d6a2cd8d2807cf215e09
cc5ae792493af5222b08212b7881cd249894f277
cb9771321920520e5edcc700c0279258da92f0fc
]
- 各クラスのテストを追加
## レビュー観点

## スクリーンショット
変更なし

<img src="https://user-images.githubusercontent.com/22112440/157238500-220993b7-61dc-4efb-86c4-337af0852cba.png" width="400px"> 